### PR TITLE
update dockerfile to handle *.gemspec on build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM jekyll/jekyll
 
-COPY ./Gemfile ./
+COPY ./Gemfile *.gemspec ./
 
 RUN bundle install
 

--- a/README.md
+++ b/README.md
@@ -68,8 +68,7 @@ help you run the container locally from within the root
 directory of the project:
 
 ```
-docker run --rm --label=jekyll --volume=$(pwd):/srv/jekyll \
--it -p 127.0.0.1:4000:4000 jekyll/jekyll
+docker run --rm --volume=$(pwd):/srv/jekyll -p 4000:4000  -it jekyll/jekyll jekyll serve
 ```
 
 This will first pull down the jekyll docker image, then install
@@ -87,7 +86,7 @@ Pick any tag name you want, it's just there so that it's easy to reference later
 `http://localhost:4000` with:
 
 ```
-docker run --rm -it -p 4000:4000 -v $(pwd):/srv/jekyll <YOUR_TAG_HERE>
+docker run --rm -p 4000:4000 -v $(pwd):/srv/jekyll <YOUR_TAG_HERE>
 ```
 
 ## License

--- a/minimal-mistakes-jekyll.gemspec
+++ b/minimal-mistakes-jekyll.gemspec
@@ -11,10 +11,6 @@ Gem::Specification.new do |spec|
 
   spec.metadata["plugin_type"] = "theme"
 
-  spec.files                   = `git ls-files -z`.split("\x0").select do |f|
-    f.match(%r{^(assets|_(data|includes|layouts|sass)/|(LICENSE|README|CHANGELOG)((\.(txt|md|markdown)|$)))}i)
-  end
-
   spec.add_runtime_dependency "jekyll", "~> 3.7"
   spec.add_runtime_dependency "jekyll-paginate", "~> 1.1"
   spec.add_runtime_dependency "jekyll-sitemap", "~> 1.2"


### PR DESCRIPTION
Because of the addition of the *.gemspec file into the build
process, it needs to be included in the Dockerfile to correctly
install all the gems.

Also, we're now suppressing a harmless warning about the git
discovery across file systems not being set.