### PR TITLE
Added stub pages for older editions & redirection from /bea/14 to /bea/2019

### DIFF
--- a/_pages/bea/bea1.md
+++ b/_pages/bea/bea1.md
@@ -1,0 +1,6 @@
+---
+title: HLT-NAACL 03 Workshop on Building Educational Applications Using Natural Language Processing
+permalink: /bea/2003
+redirect_from: /bea/1
+redirect_to: https://aclweb.org/anthology/events/ws-2003#w03-02
+---

--- a/_pages/bea/bea10.md
+++ b/_pages/bea/bea10.md
@@ -1,0 +1,6 @@
+---
+title: 10th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2015
+redirect_from: /bea/10
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea10.html
+---

--- a/_pages/bea/bea11.md
+++ b/_pages/bea/bea11.md
@@ -1,0 +1,6 @@
+---
+title: 11th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2016
+redirect_from: /bea/11
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea11.html
+---

--- a/_pages/bea/bea12.md
+++ b/_pages/bea/bea12.md
@@ -1,0 +1,6 @@
+---
+title: 12th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2017
+redirect_from: /bea/12
+redirect_to: https://www.cs.rochester.edu/~tetreaul/emnlp-bea12.html
+---

--- a/_pages/bea/bea13.md
+++ b/_pages/bea/bea13.md
@@ -1,0 +1,6 @@
+---
+title: 13th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2018
+redirect_from: /bea/13
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea13.html
+---

--- a/_pages/bea/bea14.md
+++ b/_pages/bea/bea14.md
@@ -2,6 +2,7 @@
 title: "14th Workshop on Innovative Use of NLP for Building Educational Applications"
 layout: single
 permalink: /bea/2019
+redirect_from: /bea/14
 sidebar: 
     nav: "bea"
 toc: true

--- a/_pages/bea/bea15.md
+++ b/_pages/bea/bea15.md
@@ -2,6 +2,7 @@
 title: "15th Workshop on Innovative Use of NLP for Building Educational Applications"
 layout: single
 permalink: /bea/2020
+redirect_from: /bea/15
 sidebar: 
     nav: "bea"
 toc: true

--- a/_pages/bea/bea16.md
+++ b/_pages/bea/bea16.md
@@ -2,6 +2,7 @@
 title: "16th Workshop on Innovative Use of NLP for Building Educational Applications"
 layout: single
 permalink: /bea/2021
+redirect_from: /bea/16
 sidebar: 
     nav: "bea"
 toc: true

--- a/_pages/bea/bea17.md
+++ b/_pages/bea/bea17.md
@@ -1,6 +1,7 @@
 ---
 title: 17th Workshop on Innovative Use of NLP for Building Educational Applications
 permalink: /bea/2022
+redirect_from: /bea/17
 sidebar: 
     nav: "bea"
 toc: true

--- a/_pages/bea/bea2.md
+++ b/_pages/bea/bea2.md
@@ -1,0 +1,6 @@
+---
+title: Second Workshop on Building Educational Applications Using NLP
+permalink: /bea/2005
+redirect_from: /bea/2
+redirect_to: https://aclweb.org/anthology/events/ws-2005#w05-02
+---

--- a/_pages/bea/bea3.md
+++ b/_pages/bea/bea3.md
@@ -1,0 +1,6 @@
+---
+title: 3rd Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2008
+redirect_from: /bea/3
+redirect_to: https://www.cs.rochester.edu/~tetreaul/acl-bea.html
+---

--- a/_pages/bea/bea4.md
+++ b/_pages/bea/bea4.md
@@ -1,0 +1,6 @@
+---
+title: 4th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2009
+redirect_from: /bea/4
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea4.html
+---

--- a/_pages/bea/bea5.md
+++ b/_pages/bea/bea5.md
@@ -1,0 +1,6 @@
+---
+title: 5th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2010
+redirect_from: /bea/5
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea5.html
+---

--- a/_pages/bea/bea6.md
+++ b/_pages/bea/bea6.md
@@ -1,0 +1,6 @@
+---
+title: 6th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2011
+redirect_from: /bea/6
+redirect_to: https://www.cs.rochester.edu/~tetreaul/acl-bea6.html
+---

--- a/_pages/bea/bea7.md
+++ b/_pages/bea/bea7.md
@@ -1,0 +1,6 @@
+---
+title: 7th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2012
+redirect_from: /bea/7
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea7.html
+---

--- a/_pages/bea/bea8.md
+++ b/_pages/bea/bea8.md
@@ -1,0 +1,6 @@
+---
+title: 8th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2013
+redirect_from: /bea/8
+redirect_to: https://www.cs.rochester.edu/~tetreaul/naacl-bea8.html
+---

--- a/_pages/bea/bea9.md
+++ b/_pages/bea/bea9.md
@@ -1,0 +1,6 @@
+---
+title: 9th Workshop on Innovative Use of NLP for Building Educational Applications
+permalink: /bea/2014
+redirect_from: /bea/9
+redirect_to: https://www.cs.rochester.edu/~tetreaul/acl-bea9.html
+---


### PR DESCRIPTION
I noticed that some pages redirect to /bea/14, which has been changed to /bea/2019. I added a "redirect_from" directive to make sure that these links are not broken.