### PR TITLE
Removed registration and contact info - TBC

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -55,6 +55,6 @@ beasharedtask2024:
   - title: Contact
     children:
       - title: "Registration"
-        url: https://forms.gle/XkbMDByMhckj5o4QA
+        url: 
       - title: "Email"
-        url: mailto:knorth8@gmu.edu
+        url: 

--- a/_pages/sharedtask/2024.md
+++ b/_pages/sharedtask/2024.md
@@ -12,7 +12,7 @@ sidebar:
 Shared task organized during the [BEA](/bea/2024) workshop at [NAACL 2024](https://sig-edu.org/bea/2024).<br>
 Mexico City, Mexico <br>
 June 20 or 21, 2024"
-    nav: beasharedtask2024 # <-- add navigation for CodaLab links.
+    nav: 
 ---
 
 <h1>{{ page.subtitle }}</h1>


### PR DESCRIPTION
Hi Anaïs,

Sorry to be a pain, I just have one last pull request. I have removed the registration and email from the navigation bar as they are TBC.

Thanks!

Kai